### PR TITLE
fix builds for xplode, cart2prj, prj2cart, wasmp2cart on linux (pthread and dl were not linked)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -757,7 +757,10 @@ if(BUILD_DEMO_CARTS)
     target_link_libraries(xplode tic80core png giflib)
 
     if(LINUX)
-        target_link_libraries(xplode m)
+        target_link_libraries(xplode m pthread dl)
+        target_link_libraries(cart2prj pthread dl)
+        target_link_libraries(prj2cart pthread dl)
+        target_link_libraries(wasmp2cart pthread dl)
     endif()
 
     file(GLOB DEMO_CARTS


### PR DESCRIPTION
I feel like this issue should probably go all the way upstream, it looks like even nesbox's version is missing these? or I've solved this problem in the wrong place, I'm not sure 😅 

either way, this fixes the build for us